### PR TITLE
Updated radius.py, README.md to reflect newly supported elements (N, O, F, Cl, Br, I, Tc and Sm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ files containing the following elements: `Si` `Sc` `Fe` `Co` `Ni` `Ga` `Ge` `Y`
 `Ru` `Rh` `Pd` `In` `Sn` `Sb` `La` `Ce` `Pr` `Nd` `Sm` `Eu` `Gd` `Tb` `Dy` `Ho`
 `Er` `Tm` `Yb` `Lu` `Os` `Ir` `Pt` `Th` `U` `Al` `Mo` `Hf` `Ta`. `Ag` `As` `Au`
 `B` `Ba` `Be` `Bi` `C` `Ca` `Cd` `Cr` `Cs` `Cu` `Hg` `K` `Li` `Mg` `Mn` `Na`
-`Nb` `P` `Pb` `Rb` `Re` `S` `Se` `Sr` `Te` `Ti` `Tl` `V` `W` `Zn` `Zr`
+`Nb` `P` `Pb` `Rb` `Re` `S` `Se` `Sr` `Te` `Ti` `Tl` `V` `W` `Zn` `Zr` `Tc` `N`
+`O` `F` `Cl` `Br` `I` `Sm`
 
-:warning: You may use CIF Cleaner (https://github.com/bobleesj/cif-cleaner) to
-interactively filter `.cif` files based on composition type (binary, ternary)
-and elements without programming.
+:Note: The Pauling CN 12 radii values for some gases [N, O, F, Cl, Br and I] as well as Tc and Sm were interpolated using 
+Gaussian Process Regression. The CIF radii for the aforementioned gases were compiled averages of low-temperature structures 
+from PCD.
 
 ### Adding more elements
 

--- a/core/data/radius.py
+++ b/core/data/radius.py
@@ -74,6 +74,15 @@ def get_radius_data() -> dict:
         "W": [1.364, 1.394],
         "Zn": [1.333, 1.379],
         "Zr": [1.553, 1.597],
+        # Below values were interpolated using GPR
+        "N": [0.536, 0.880],
+        "O": [0.611, 1.115],
+        "F": [0.709, 1.600],
+        "Cl": [0.968, 1.448],
+        "Br": [1.141, 1.659],
+        "I": [1.359, 1.338],
+        "Tc": [1.355, 1.803],
+        "Pm": [1.797, 1.635]
     }
 
     data: dict = {k: {"CIF_radius": v[0], "Pauling_radius_CN12": v[1]} for k, v in rad_data.items()}


### PR DESCRIPTION
This PR closes #8. Updated radius.py, README.md to reflect newly supported elements. Pauling CN 12 radii values for some gases [N, O, F, Cl, Br, and I] as well as Tc and Sm were interpolated using Gaussian Process Regression. The CIF radii for the aforementioned gases were compiled averages of low-temperature structures from PCD.

![predictions_plot](https://github.com/user-attachments/assets/56d4111c-dbc1-4d01-b475-9267839e128f)

Code block used to generate these values are below:
```python
import pandas as pd
import numpy as np
from sklearn.gaussian_process import GaussianProcessRegressor
from sklearn.gaussian_process.kernels import RBF, ConstantKernel as C

# Load data
excel_path = '/Users/emiljaffal/Downloads/element_properties_for_ML.xlsx'
df_training = pd.read_excel(excel_path, sheet_name='training')
df_y = pd.read_excel(excel_path, sheet_name='y')
# print(df_y.iloc[0:10])

# Combine into one DataFrame
df = df_training.copy()
df['Pauling_radius_CN12'] = df_y['Pauling_radius_CN12']

# Features for model (atomic_number as example, add more if you have)
feature_cols = ['atomic_number']
X_all = df[feature_cols].values

# Split into known and unknown
mask_known = ~(df['Pauling_radius_CN12'] == -1).values
X_known = X_all[mask_known]
y_known = df.loc[mask_known, 'Pauling_radius_CN12'].values

# Train model on known
kernel = C(1.0, (1e-3, 1e3)) * RBF(10, (1e-2, 1e2))
clf = GaussianProcessRegressor(kernel=kernel, n_restarts_optimizer=10)
clf.fit(X_known, y_known)

# Predict for all
y_pred = clf.predict(X_all)

# Build results DataFrame
df_results = pd.DataFrame({
    "Symbol": df['symbol'],
    "Atomic Number": df['atomic_number'],
    "Actual": df['Pauling_radius_CN12'],
    "Predicted": y_pred
})
```

Visualization code below:

```python
import matplotlib.pyplot as plt
import os

highlight_atomic_numbers = [8, 9, 17, 35, 43, 53, 61]

plt.figure(figsize=(8,6))

# Plot actual as blue empty circles
plt.plot(
    df_results["Atomic Number"], 
    df_results["Actual"], 
    'o', 
    markerfacecolor='none', 
    markeredgecolor='blue', 
    label='Reported',
    markersize=7
)

# Plot predicted as red triangles except for highlighted
mask_highlight = df_results["Atomic Number"].isin(highlight_atomic_numbers)
mask_normal = ~mask_highlight

# Red triangles for normal
plt.plot(
    df_results.loc[mask_normal, "Atomic Number"], 
    df_results.loc[mask_normal, "Predicted"], 
    '^', 
    color='red', 
    label='GPR predicted',
    markersize=6
)

# Yellow triangles for highlighted
plt.plot(
    df_results.loc[mask_highlight, "Atomic Number"], 
    df_results.loc[mask_highlight, "Predicted"], 
    '^', 
    color='yellow', 
    markeredgecolor='orange',
    label='Interpolated',
    markersize=8
)

plt.xlabel("atomic number", fontsize=20)
plt.ylabel("Pauling CN12 radius", fontsize=20)
plt.ylim(0.7, 3.2)
# Reduce legend marker-to-text spacing with handlelength
plt.legend(fontsize=20, loc='best', frameon=False, handlelength=.75, handletextpad=0.5)
plt.xticks(fontsize=20)
plt.yticks(fontsize=20)
plt.tight_layout()
output_path = os.path.expanduser("~/Downloads/predictions_plot.png")
plt.savefig(output_path, dpi=300, bbox_inches='tight')
plt.show()
```
